### PR TITLE
feat: self check after adding proof

### DIFF
--- a/credential/common/jsonmap/jsonmap.go
+++ b/credential/common/jsonmap/jsonmap.go
@@ -128,6 +128,16 @@ func (m *JSONMap) AddECDSAProof(signerProvider signer.SignerProvider, verificati
 	proof.ProofValue = hex.EncodeToString(signature)
 	(*m)["proof"] = util.SerializeProofs([]dto.Proof{*proof})
 
+	// Self-verify after adding proof to provide detailed errors early (expected/got)
+	// instead of deferring to later Verify() calls.
+	isValid, err := m.VerifyProof(didBaseURL)
+	if err != nil {
+		return fmt.Errorf("jsonmap: proof self-verification failed: %w", err)
+	}
+	if !isValid {
+		return fmt.Errorf("jsonmap: proof self-verification failed: invalid proof")
+	}
+
 	return nil
 }
 
@@ -180,17 +190,24 @@ func (m *JSONMap) VerifyProof(didBaseURL string) (bool, error) {
 		return false, fmt.Errorf("JSONMap is nil")
 	}
 
-	proofs, ok := (*m)["proof"].([]interface{})
+	rawProofField, hasProofField := (*m)["proof"]
+	if !hasProofField {
+		return false, fmt.Errorf("JSONMap has no proof")
+	}
+
+	proofs, ok := rawProofField.([]interface{})
 	if !ok {
-		if proof, exists := (*m)["proof"]; exists {
-			proofs = []interface{}{proof}
-		} else {
-			return false, fmt.Errorf("JSONMap has no proof")
-		}
+		proofs = []interface{}{rawProofField}
+	}
+	if len(proofs) == 0 {
+		return false, fmt.Errorf("expected proof array to have at least 1 entry, got 0")
 	}
 	proof, err := ParseRawToProof(proofs[0])
 	if err != nil {
 		return false, fmt.Errorf("failed to parse proof: %w", err)
+	}
+	if proof.Type == "" {
+		return false, fmt.Errorf("expected proof.type to be non-empty string, got empty")
 	}
 
 	if proof.Type == JwtProof2020 {
@@ -205,10 +222,36 @@ func (m *JSONMap) VerifyProof(didBaseURL string) (bool, error) {
 			return false, fmt.Errorf("failed to resolve public key: %w", err)
 		}
 
-		return crypto.VerifyJwtProof((*map[string]interface{})(m), publicKey)
+		// VerifyJwtProof expects proof to be a map with a "jwt" field, not an array.
+		rawProofMap, ok := proofs[0].(map[string]interface{})
+		if !ok {
+			return false, fmt.Errorf("expected proof to be map[string]interface{} for %s, got %T", JwtProof2020, proofs[0])
+		}
+
+		tmp := make(map[string]interface{}, len(*m))
+		for k, v := range *m {
+			tmp[k] = v
+		}
+		tmp["proof"] = rawProofMap
+
+		verified, err := crypto.VerifyJwtProof(&tmp, publicKey)
+		if err != nil {
+			return false, err
+		}
+		if !verified {
+			return false, fmt.Errorf("signature verification failed: expected %s signature to match resolved public key, but it did not", JwtProof2020)
+		}
+		return true, nil
 	} else if proof.Type == EcdsaSecp256k1Signature2019 || proof.Type == ECDSASECPKEY {
 
-		return m.verifyEcdsaProofLegacy()
+		verified, err := m.verifyEcdsaProofLegacyFromRaw(proofs[0])
+		if err != nil {
+			return false, err
+		}
+		if !verified {
+			return false, fmt.Errorf("signature verification failed: expected legacy ECDSA proof signature to match verificationMethod, but it did not")
+		}
+		return true, nil
 	} else if proof.Type == DataIntegrityProof && proof.Cryptosuite == ECDSARDFC2019 {
 		resolver := verificationmethod.NewResolver(didBaseURL)
 		publicKey, err := resolver.GetPublicKey(proof.VerificationMethod)
@@ -216,10 +259,20 @@ func (m *JSONMap) VerifyProof(didBaseURL string) (bool, error) {
 			return false, fmt.Errorf("failed to resolve public key: %w", err)
 		}
 
-		return m.verifyECDSA(publicKey, &proof)
+		verified, err := m.verifyECDSA(publicKey, &proof)
+		if err != nil {
+			return false, err
+		}
+		if !verified {
+			return false, fmt.Errorf("signature verification failed: expected %s/%s signature to match verificationMethod %q, but it did not", DataIntegrityProof, ECDSARDFC2019, proof.VerificationMethod)
+		}
+		return true, nil
 	} else {
 
-		return false, fmt.Errorf("unsupported proof type: %s", proof.Type)
+		if proof.Type == DataIntegrityProof && proof.Cryptosuite != ECDSARDFC2019 {
+			return false, fmt.Errorf("unsupported cryptosuite for %s: expected %q, got %q", DataIntegrityProof, ECDSARDFC2019, proof.Cryptosuite)
+		}
+		return false, fmt.Errorf("unsupported proof type: expected one of %q, %q, %q, got %q", JwtProof2020, DataIntegrityProof, EcdsaSecp256k1Signature2019, proof.Type)
 	}
 }
 
@@ -229,26 +282,36 @@ func (m *JSONMap) verifyECDSA(publicKey string, proof *dto.Proof) (bool, error) 
 	if err != nil {
 		return false, fmt.Errorf("failed to canonicalize JSONMap: %w", err)
 	}
+	if len(doc) != 32 {
+		return false, fmt.Errorf("invalid signing digest length: expected 32 bytes, got %d", len(doc))
+	}
 
 	return crypto.ECDSAVerifySignature(publicKey, proof.ProofValue, doc)
 }
 
-// verifyEcdsaProofLegacy verifies an ECDSA-signed JSONMap.
-// This function support lecacy VC for compatibility
-func (m *JSONMap) verifyEcdsaProofLegacy() (bool, error) {
-
-	proofValue, ok := (*m)["proof"].(map[string]interface{})["proofValue"].(string)
-	if !ok || proofValue == "" {
-		return false, fmt.Errorf("proof value is missing or invalid in the request")
+// verifyEcdsaProofLegacyFromRaw verifies a legacy ECDSA-signed JSONMap.
+// This function supports legacy VC for compatibility.
+func (m *JSONMap) verifyEcdsaProofLegacyFromRaw(rawProof interface{}) (bool, error) {
+	proofMap, ok := rawProof.(map[string]interface{})
+	if !ok {
+		return false, fmt.Errorf("expected proof to be map[string]interface{}, got %T", rawProof)
 	}
-	publicKeyHex, ok := (*m)["proof"].(map[string]interface{})["verificationMethod"].(string)
+
+	proofValue, ok := proofMap["proofValue"].(string)
+	if !ok || proofValue == "" {
+		return false, fmt.Errorf("expected proof.proofValue to be non-empty string, got %T", proofMap["proofValue"])
+	}
+	publicKeyHex, ok := proofMap["verificationMethod"].(string)
 	if !ok || publicKeyHex == "" {
-		return false, fmt.Errorf("proof verificationMethod is missing or invalid in the request")
+		return false, fmt.Errorf("expected proof.verificationMethod to be non-empty string, got %T", proofMap["verificationMethod"])
 	}
 
 	signatureBytes, err := hex.DecodeString(proofValue)
 	if err != nil {
 		return false, fmt.Errorf("failed to decode proof value to bytes: %w", err)
+	}
+	if err := signer.ValidateSignatureLength(signatureBytes); err != nil {
+		return false, err
 	}
 
 	reqCopy := make(map[string]interface{})

--- a/credential/common/jsonmap/jsonmap_test.go
+++ b/credential/common/jsonmap/jsonmap_test.go
@@ -2,34 +2,87 @@ package jsonmap
 
 import (
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/pilacorp/go-credential-sdk/credential/common/signer"
 )
 
-type testSigner struct {
-	sig []byte
+type truncatingSigner struct {
+	base signer.SignerProvider
 }
 
-func (s *testSigner) Sign(hashPayload []byte) ([]byte, error) {
-	if len(hashPayload) != 32 {
-		return nil, signer.ValidateSignatureLength(hashPayload)
+func (s *truncatingSigner) Sign(hashPayload []byte) ([]byte, error) {
+	sig, err := s.base.Sign(hashPayload)
+	if err != nil {
+		return nil, err
 	}
-	return s.sig, nil
+	if len(sig) == 65 {
+		return sig[:64], nil
+	}
+	return sig, nil
+}
+
+func newTestResolverServer(t *testing.T, did, vmID, publicKeyHex string) *httptest.Server {
+	t.Helper()
+
+	doc := map[string]interface{}{
+		"@context": []string{"https://www.w3.org/ns/did/v1"},
+		"id":       did,
+		"verificationMethod": []map[string]interface{}{
+			{
+				"id":           vmID,
+				"type":         "EcdsaSecp256k1VerificationKey2019",
+				"controller":   did,
+				"publicKeyHex": "0x" + publicKeyHex,
+			},
+		},
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/") {
+			http.NotFound(w, r)
+			return
+		}
+		if strings.TrimPrefix(r.URL.Path, "/") != url.PathEscape(did) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(doc)
+	}))
 }
 
 func TestJSONMap_AddECDSAProof_Accepts64ByteSignature(t *testing.T) {
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	privHex := hex.EncodeToString(crypto.FromECDSA(priv))
+	pubHex := hex.EncodeToString(crypto.FromECDSAPub(&priv.PublicKey))
+
+	did := "did:example:issuer"
+	vmID := "did:example:issuer#key-1"
+	resolverServer := newTestResolverServer(t, did, vmID, pubHex)
+	defer resolverServer.Close()
+
 	m := JSONMap{
 		"issuer": "did:example:issuer",
 		"type":   "VerifiableCredential",
 	}
 
-	sig64 := make([]byte, 64)
-	for i := range sig64 {
-		sig64[i] = 0xAB
+	defaultSigner, err := signer.NewDefaultProvider(privHex)
+	if err != nil {
+		t.Fatalf("NewDefaultProvider: %v", err)
 	}
 
-	err := (&m).AddECDSAProof(&testSigner{sig: sig64}, "did:example:issuer#key-1", "assertionMethod", "https://example.invalid")
+	err = (&m).AddECDSAProof(&truncatingSigner{base: defaultSigner}, vmID, "assertionMethod", resolverServer.URL)
 	if err != nil {
 		t.Fatalf("AddECDSAProof error: %v", err)
 	}
@@ -45,17 +98,29 @@ func TestJSONMap_AddECDSAProof_Accepts64ByteSignature(t *testing.T) {
 }
 
 func TestJSONMap_AddECDSAProof_Accepts65ByteSignature(t *testing.T) {
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	privHex := hex.EncodeToString(crypto.FromECDSA(priv))
+	pubHex := hex.EncodeToString(crypto.FromECDSAPub(&priv.PublicKey))
+
+	did := "did:example:issuer"
+	vmID := "did:example:issuer#key-1"
+	resolverServer := newTestResolverServer(t, did, vmID, pubHex)
+	defer resolverServer.Close()
+
 	m := JSONMap{
 		"issuer": "did:example:issuer",
 		"type":   "VerifiableCredential",
 	}
 
-	sig65 := make([]byte, 65)
-	for i := range sig65 {
-		sig65[i] = 0xCD
+	defaultSigner, err := signer.NewDefaultProvider(privHex)
+	if err != nil {
+		t.Fatalf("NewDefaultProvider: %v", err)
 	}
 
-	err := (&m).AddECDSAProof(&testSigner{sig: sig65}, "did:example:issuer#key-1", "assertionMethod", "https://example.invalid")
+	err = (&m).AddECDSAProof(defaultSigner, vmID, "assertionMethod", resolverServer.URL)
 	if err != nil {
 		t.Fatalf("AddECDSAProof error: %v", err)
 	}
@@ -76,9 +141,19 @@ func TestJSONMap_AddECDSAProof_RejectsInvalidSignatureLength(t *testing.T) {
 		"type":   "VerifiableCredential",
 	}
 
-	err := (&m).AddECDSAProof(&testSigner{sig: make([]byte, 66)}, "did:example:issuer#key-1", "assertionMethod", "https://example.invalid")
+	err := (&m).AddECDSAProof(&fakeSigner{sig: make([]byte, 66)}, "did:example:issuer#key-1", "assertionMethod", "https://example.invalid")
 	if err == nil {
 		t.Fatalf("expected error for invalid signature length")
 	}
 }
 
+type fakeSigner struct {
+	sig []byte
+}
+
+func (s *fakeSigner) Sign(hashPayload []byte) ([]byte, error) {
+	if len(hashPayload) != 32 {
+		return nil, fmt.Errorf("invalid signing digest length: got %d, want 32", len(hashPayload))
+	}
+	return s.sig, nil
+}

--- a/credential/common/jwt/signing_method.go
+++ b/credential/common/jwt/signing_method.go
@@ -52,7 +52,7 @@ func (m *SigningMethodES256K) Verify(signingString string, signature []byte, key
 	}
 
 	if len(signature) != 64 {
-		return fmt.Errorf("invalid signature length")
+		return fmt.Errorf("invalid signature length: expected 64, got %d", len(signature))
 	}
 
 	hash := sha256.Sum256([]byte(signingString))
@@ -60,7 +60,7 @@ func (m *SigningMethodES256K) Verify(signingString string, signature []byte, key
 	s := new(big.Int).SetBytes(signature[32:])
 
 	if !ecdsa.Verify(publicKey, hash[:], r, s) {
-		return fmt.Errorf("signature verification failed")
+		return fmt.Errorf("signature verification failed: expected signature to verify with the resolved public key, but it did not")
 	}
 
 	return nil

--- a/credential/vc/json_credential.go
+++ b/credential/vc/json_credential.go
@@ -159,7 +159,7 @@ func (e *JSONCredential) executeOptions(opts ...CredentialOpt) error {
 			}
 
 			if !isValid {
-				return fmt.Errorf("invalid proof")
+				return fmt.Errorf("verify proof: invalid proof")
 			}
 
 			return nil

--- a/credential/vc/json_credential.go
+++ b/credential/vc/json_credential.go
@@ -88,6 +88,7 @@ func (e *JSONCredential) AddCustomProof(proof *dto.Proof, opts ...CredentialOpt)
 		return fmt.Errorf("proof cannot be nil")
 	}
 
+	opts = append(opts, WithVerifyProof())
 	err := e.executeOptions(opts...)
 	if err != nil {
 		return err

--- a/credential/vc/jwt_credential.go
+++ b/credential/vc/jwt_credential.go
@@ -183,18 +183,34 @@ func (j *JWTCredential) AddProofByProvider(signerProvider signer.SignerProvider,
 		return fmt.Errorf("signer provider cannot be nil")
 	}
 
+	options := getOptions(opts...)
+
 	jwtSigner := jwt.NewJWTSigner(signerProvider)
 	signature, err := jwtSigner.SignString(j.signingInput)
 	if err != nil {
 		return fmt.Errorf("failed to sign signing input: %w", err)
 	}
 
+	// Set signature before running option-driven verification.
+	j.signature = signature
+
+	// Self-verify after signing to surface detailed errors early.
+	if len(j.disclosures) == 0 {
+		serialized, err := j.Serialize()
+		if err != nil {
+			return fmt.Errorf("proof self-verification failed: serialize credential: %w", err)
+		}
+
+		verifier := jwt.NewJWTVerifierWithResolver(options.resolver)
+		if err := verifier.VerifyJWT(serialized.(string)); err != nil {
+			return fmt.Errorf("proof self-verification failed: %w", err)
+		}
+	}
+
 	err = j.executeOptions(opts...)
 	if err != nil {
 		return err
 	}
-
-	j.signature = signature
 	return nil
 }
 
@@ -320,7 +336,7 @@ func (j *JWTCredential) extractPayload() (map[string]interface{}, string, error)
 func (j *JWTCredential) buildCredential(payload map[string]interface{}, header string, vc map[string]interface{}, disc []string) (*JWTCredential, error) {
 	// Replace vc claim while preserving all other payload claims (iss, sub, exp, iat, nbf, jti, etc.)
 	payload["vc"] = vc
-	
+
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal payload: %w", err)

--- a/credential/vp/json_presentation.go
+++ b/credential/vp/json_presentation.go
@@ -134,10 +134,10 @@ func (e *JSONPresentation) executeOptions(opts ...PresentationOpt) error {
 	if options.isVerifyProof {
 		isValid, err := (*jsonmap.JSONMap)(&e.presentationData).VerifyProof(options.didBaseURL)
 		if err != nil {
-			return fmt.Errorf("failed to verify presentation: %w", err)
+			return fmt.Errorf("verify proof: %w", err)
 		}
 		if !isValid {
-			return fmt.Errorf("invalid proof")
+			return fmt.Errorf("verify proof: invalid proof")
 		}
 	}
 

--- a/credential/vp/jwt_presentation.go
+++ b/credential/vp/jwt_presentation.go
@@ -153,6 +153,8 @@ func (j *JWTPresentation) AddProofByProvider(signerProvider signer.SignerProvide
 		return fmt.Errorf("signer provider cannot be nil")
 	}
 
+	options := getOptions(opts...)
+
 	jwtSigner := jwt.NewJWTSigner(signerProvider)
 
 	// Sign the existing signing input
@@ -161,13 +163,24 @@ func (j *JWTPresentation) AddProofByProvider(signerProvider signer.SignerProvide
 		return fmt.Errorf("failed to sign signing input: %w", err)
 	}
 
+	// Set signature before running option-driven verification.
+	j.signature = signature
+
+	// Self-verify after signing to surface detailed errors early.
+	serialized, err := j.Serialize()
+	if err != nil {
+		return fmt.Errorf("proof self-verification failed: failed to serialize presentation: %w", err)
+	}
+
+	verifier := jwt.NewJWTVerifier(options.didBaseURL)
+	if err := verifier.VerifyJWT(serialized.(string)); err != nil {
+		return fmt.Errorf("proof self-verification failed: %w", err)
+	}
+
 	err = j.executeOptions(opts...)
 	if err != nil {
 		return err
 	}
-
-	// Update signature
-	j.signature = signature
 
 	return nil
 }
@@ -241,7 +254,7 @@ func (j *JWTPresentation) executeOptions(opts ...PresentationOpt) error {
 		verifier := jwt.NewJWTVerifier(options.didBaseURL)
 		err = verifier.VerifyJWT(serialized.(string))
 		if err != nil {
-			return fmt.Errorf("failed to verify presentation: %w", err)
+			return fmt.Errorf("verify proof: %w", err)
 		}
 	}
 


### PR DESCRIPTION
This PR improves proof verification and error reporting across JSON/JWT credentials and presentations.
- Adds post-sign self-verification so `AddProofByProvider(...)` verifies immediately after signing and fails fast with actionable errors (expected vs got), instead of waiting for `Verify()` and returning generic “invalid proof/signature”.
- Enhances `jsonmap.VerifyProof()` to return detailed validation errors for malformed proof fields, unsupported proof/cryptosuite, missing/invalid verificationMethod, invalid digest length, and signature mismatches (no more silent (false, nil) on verify failure).
- Aligns verification error messages across VC/VP JSON + JWT flows, and improves ES256K verification errors to include expected signature length and mismatch context.
- Updates unit tests to stay network-free by using an httptest DID resolver for JSONMap proof verification.