### PR TITLE
feat: implement VerifyVCHashByTx method and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,7 +968,7 @@ if err != nil {
 
 A `false` result (with a `nil` error) means the proof does not validate; a non-nil
 error means the call itself failed (bad input, RPC error, or the tree does not
-exist). A runnable example lives in [`credential/vccontract/example`](credential/vccontract/example).
+exist). A runnable example lives in [`credential/examples/vccontract/verifyonchain`](credential/examples/vccontract/verifyonchain).
 
 ## <a name="vccontract-api"></a>API
 

--- a/credential/examples/vccontract/verifybytx/main.go
+++ b/credential/examples/vccontract/verifybytx/main.go
@@ -1,7 +1,7 @@
 // Command verifybytx demonstrates how a client verifies that a VC hash is
 // anchored by a SPECIFIC transaction, using vccontract.CredentialRegistry.
 //
-// Unlike the sibling example (which checks the tree's current root via
+// Unlike the verifyonchain example (which checks the tree's current root via
 // verifyVC), this folds the Merkle proof locally against the root that a given
 // transaction recorded on-chain. Use it for an unsealed tree whose current root
 // has since been overwritten by a later anchoring: the proof and the tx hash
@@ -14,7 +14,7 @@
 //
 // Run:
 //
-//	go run ./credential/vccontract/example/verifybytx
+//	go run ./credential/examples/vccontract/verifybytx
 package main
 
 import (

--- a/credential/examples/vccontract/verifyonchain/main.go
+++ b/credential/examples/vccontract/verifyonchain/main.go
@@ -1,5 +1,5 @@
-// Command example demonstrates how a client verifies that a VC hash is anchored
-// on-chain using the vccontract.CredentialRegistry.
+// Command verifyonchain demonstrates how a client verifies that a VC hash is
+// anchored on-chain using the vccontract.CredentialRegistry.
 //
 // The proof components (issuer address, tree index, leaf, and sibling proof) are
 // assumed to already be in hand — for example, fetched from the authen-service
@@ -8,7 +8,7 @@
 //
 // Run:
 //
-//	go run ./credential/vccontract/example
+//	go run ./credential/examples/vccontract/verifyonchain
 package main
 
 import (

--- a/credential/vccontract/README.md
+++ b/credential/vccontract/README.md
@@ -3,27 +3,44 @@
 `vccontract` is a lightweight, **read-only** client for the Credential Registry
 smart contract. It lets a holder or any third party verify that a Verifiable
 Credential (VC) hash is anchored on-chain — without a private key and without
-spending gas (every call is an `eth_call`).
+spending gas (every call is an `eth_call` or a receipt read).
 
 ## How anchoring works
 
 The issuer service groups VC hashes per issuer into Merkle trees and publishes
 each tree's **root** on-chain (one root per `issuer` + `treeIndex`). A VC hash is
 a **leaf**. Membership is proven with a Merkle **proof** — the ordered list of
-sibling hashes that fold up to the root. Verification (folding the proof and
-comparing to the stored root) is done by the contract itself, so this package
-only has to pass the proof through.
+sibling hashes that fold up to the root.
+
+An **unsealed** tree keeps growing: each new anchoring overwrites the tree's
+stored root. So a proof captured at an earlier anchoring no longer folds to the
+*current* root — only to the root that was live when the proof was taken. That is
+why there are two verification paths.
+
+## Two ways to verify
+
+- **`VerifyVCHashOnChain`** — checks the proof against the tree's **current**
+  root. The contract's `verifyVC(...)` view function folds the proof and returns
+  the verdict. Use this for a sealed tree, or when the proof was taken against the
+  latest anchoring.
+- **`VerifyVCHashByTx`** — checks the proof against the root that a **specific
+  transaction** anchored, read from that transaction's receipt logs
+  (`BatchTreesUpdated`). The proof is folded locally (sorted-pair keccak256, the
+  same rule the contract uses). Use this when the tree is unsealed and its current
+  root has moved on: pass the tx hash of the anchoring the proof belongs to.
 
 ## Inputs
 
 You supply the proof components directly (this package does not call the
 authen-service API). They typically come from the authen-service proof endpoint
-`GetVCProofByHash` / `GetVCProofByID`, which returns exactly these fields:
+`GetVCProofByHash` / `GetVCProofByID`, which returns exactly these fields
+(including `TxHash` for the by-transaction path):
 
 - `IssuerAddress` — issuer's Ethereum address (`0x…`)
 - `TreeIndex` — which tree of that issuer
 - `Leaf` — the VC hash (32-byte hex)
 - `Proof` — ordered sibling hashes (32-byte hex each; empty for a single-leaf tree)
+- `TxHash` — hash of the anchoring transaction (32-byte hex) — **`VerifyVCHashByTx` only**
 
 ## Usage
 
@@ -36,7 +53,11 @@ if err != nil {
     // handle
 }
 defer registry.Close()
+```
 
+Against the current root:
+
+```go
 req := &vccontract.VerifyRequest{
     IssuerAddress: "0x...Issuer",
     TreeIndex:     0,
@@ -47,20 +68,44 @@ req := &vccontract.VerifyRequest{
 ok, err := registry.VerifyVCHashOnChain(context.Background(), req)
 ```
 
-`VerifyVCHashOnChain` calls the contract's `verifyVC(issuer, treeIndex, leaf, proof)`
-view function. A `true` result means the VC hash is anchored in the issuer's tree;
-a `false` result (with a `nil` error) means the proof does not validate. A non-nil
-error means the call itself failed — bad input, RPC error, or the tree does not
-exist.
+Against the root a specific transaction anchored:
+
+```go
+req := &vccontract.VerifyByTxRequest{
+    IssuerAddress: "0x...Issuer",
+    TreeIndex:     0,
+    Leaf:          "0x...vcHash",
+    Proof:         []string{"0x...", "0x..."},
+    TxHash:        "0x...anchoringTx",
+}
+
+ok, err := registry.VerifyVCHashByTx(context.Background(), req)
+if errors.Is(err, vccontract.ErrTxNotFound) {
+    // the tx is unknown or not yet mined — retry later
+}
+```
+
+For both, `ok == true` means the VC hash is anchored; `ok == false` with a
+`nil` error means the proof does not validate. For `VerifyVCHashByTx`, a `false`
+with `nil` error also covers a reverted transaction (`ErrTxReverted`) or a
+transaction that anchored no root for this issuer and tree index
+(`ErrRootNotAnchored`) — in both cases the transaction simply cannot attest the
+leaf. A non-nil error means the check could not be completed — bad input, an RPC
+error, or (for the by-tx path) the transaction not being found (`ErrTxNotFound`).
 
 ## API
 
 - `NewCredentialRegistry(rpcURL, contractAddress string) (*CredentialRegistry, error)` —
   connect to the chain (RPC connection is required).
 - `(*CredentialRegistry) VerifyVCHashOnChain(ctx, *VerifyRequest) (bool, error)` —
-  verify a VC hash against its on-chain tree.
+  verify a VC hash against the tree's current on-chain root.
+- `(*CredentialRegistry) VerifyVCHashByTx(ctx, *VerifyByTxRequest) (bool, error)` —
+  verify a VC hash against the root a specific transaction anchored.
+- `(*CredentialRegistry) GetAnchoredRoot(ctx, txHash, issuer, treeIndex) ([32]byte, error)` —
+  read the root a transaction recorded for an issuer/tree (returns `ErrTxNotFound`,
+  `ErrTxReverted`, or `ErrRootNotAnchored` as appropriate).
 - `(*CredentialRegistry) GetTreeRoot(ctx, issuer, treeIndex) ([32]byte, error)` —
-  read the anchored Merkle root (zero value = no such tree).
+  read the current anchored Merkle root (zero value = no such tree).
 - `(*CredentialRegistry) HasTree(ctx, issuer, treeIndex) (bool, error)` —
   whether the issuer has an anchored tree at that index.
 - `(*CredentialRegistry) Close()` — release the RPC connection.
@@ -68,10 +113,11 @@ exist.
 Reuse a single `CredentialRegistry` across calls (it holds a live, concurrency-safe
 RPC client) and `Close()` it on shutdown rather than creating one per request.
 
-## Example
+## Examples
 
-A runnable example against the testnet lives in `example/`:
+Runnable examples against the testnet live under `example/`:
 
 ```
-go run ./credential/vccontract/example
+go run ./credential/vccontract/example            # verify against current root
+go run ./credential/vccontract/example/verifybytx # verify against a tx's anchored root
 ```

--- a/credential/vccontract/README.md
+++ b/credential/vccontract/README.md
@@ -115,9 +115,9 @@ RPC client) and `Close()` it on shutdown rather than creating one per request.
 
 ## Examples
 
-Runnable examples against the testnet live under `example/`:
+Runnable examples against the testnet live under `credential/examples/vccontract/`:
 
 ```
-go run ./credential/vccontract/example            # verify against current root
-go run ./credential/vccontract/example/verifybytx # verify against a tx's anchored root
+go run ./credential/examples/vccontract/verifyonchain # verify against current root
+go run ./credential/examples/vccontract/verifybytx    # verify against a tx's anchored root
 ```

--- a/credential/vccontract/example/verifybytx/main.go
+++ b/credential/vccontract/example/verifybytx/main.go
@@ -1,0 +1,70 @@
+// Command verifybytx demonstrates how a client verifies that a VC hash is
+// anchored by a SPECIFIC transaction, using vccontract.CredentialRegistry.
+//
+// Unlike the sibling example (which checks the tree's current root via
+// verifyVC), this folds the Merkle proof locally against the root that a given
+// transaction recorded on-chain. Use it for an unsealed tree whose current root
+// has since been overwritten by a later anchoring: the proof and the tx hash
+// must come from the same anchoring.
+//
+// The proof components (issuer address, tree index, leaf, sibling proof, and the
+// anchoring tx hash) are assumed to already be in hand — for example, from the
+// authen-service proof API (GetVCProofByHash / GetVCProofByID), whose response
+// carries the TxHash of the anchoring.
+//
+// Run:
+//
+//	go run ./credential/vccontract/example/verifybytx
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/pilacorp/go-credential-sdk/credential/vccontract"
+)
+
+func main() {
+	const (
+		rpcURL          = "https://rpc-testnet-new.pila.vn"
+		contractAddress = "0x7F58Eb7eaEe52768970EC3796bdD146286EF82C6"
+	)
+
+	registry, err := vccontract.NewCredentialRegistry(rpcURL, contractAddress)
+	if err != nil {
+		log.Fatalf("failed to create registry: %v", err)
+	}
+	defer registry.Close()
+
+	// Proof components plus the anchoring tx hash (typically from the
+	// authen-service proof endpoint).
+	req := &vccontract.VerifyByTxRequest{
+		IssuerAddress: "0xe4b13a02f5f06f4fc675550478208f39d1ee75bb",
+		TreeIndex:     6,
+		Leaf:          "0x01659e2bd15fe18252c9f07e0d948996e7d47a6c23c22db479a89caa87679e98",
+		Proof: []string{
+			"0x01659e2bd15fe18252c9f77e0d948996e7d47a6c23c22db479a89caa87679e98",
+			"0x2065867413300fdd60d7155f38657ca04b1194d2ca4be86f575a4bdb6566304c",
+			"0xe2a9e8aca918f473cf30c3f761535cbe687d49c27ad4c0ee9be3d7101b814b51",
+		},
+		TxHash: "0xd1432a03f29ebb9408c7bcc2fd557a535941293051245ec4d76116d3d10b42c4",
+	}
+
+	ctx := context.Background()
+
+	ok, err := registry.VerifyVCHashByTx(ctx, req)
+	if errors.Is(err, vccontract.ErrTxNotFound) {
+		log.Fatalf("anchoring transaction not found or not yet mined")
+	}
+	if err != nil {
+		log.Fatalf("VerifyVCHashByTx failed: %v", err)
+	}
+
+	if ok {
+		fmt.Println("VC hash is anchored by the given transaction ✓")
+	} else {
+		fmt.Println("VC hash is NOT anchored by the given transaction ✗")
+	}
+}

--- a/credential/vccontract/model.go
+++ b/credential/vccontract/model.go
@@ -7,14 +7,21 @@
 // that a specific VC hash is included in a given tree by supplying a Merkle proof.
 //
 // This package does NOT issue credentials, build trees, or submit transactions.
-// It only performs read-only (eth_call) verification against the chain, so it
-// never needs a private key and never spends gas. The caller is expected to
-// already have the proof components (issuer address, tree index, leaf, and
-// sibling proof) — typically obtained from the authen-service proof API.
+// It only performs read-only (eth_call and receipt reads) verification against the
+// chain, so it never needs a private key and never spends gas. The caller is
+// expected to already have the proof components (issuer address, tree index, leaf,
+// and sibling proof) — typically obtained from the authen-service proof API.
 //
-// Verification is done via VerifyVCHashOnChain, which calls the contract's
-// verifyVC(...) view function: the contract folds the Merkle proof up to the
-// stored root and returns the verdict.
+// Two verification paths are offered:
+//
+//   - VerifyVCHashOnChain calls the contract's verifyVC(...) view function against
+//     the tree's CURRENT root: the contract folds the Merkle proof up to the stored
+//     root and returns the verdict.
+//   - VerifyVCHashByTx folds the proof locally against the root that a SPECIFIC
+//     transaction anchored, read from that transaction's receipt logs. Use this for
+//     an unsealed tree whose current root has since been overwritten by a later
+//     anchoring — a proof taken at an earlier anchoring only matches the root
+//     recorded in that anchoring's transaction.
 package vccontract
 
 import (
@@ -62,6 +69,57 @@ func (r *VerifyRequest) Validate() error {
 		if err := validateHash32(p); err != nil {
 			return fmt.Errorf("invalid proof element at index %d: %w", i, err)
 		}
+	}
+
+	return nil
+}
+
+// VerifyByTxRequest holds the Merkle proof components plus the hash of the
+// transaction that anchored the tree root the proof was generated against.
+//
+// It carries the same fields as VerifyRequest with one addition, TxHash, which
+// pins verification to the root recorded by a specific anchoring rather than the
+// tree's current (possibly overwritten) root.
+type VerifyByTxRequest struct {
+	// IssuerAddress is the issuer's Ethereum address (0x...). It identifies which
+	// issuer's tree the leaf is expected to belong to.
+	IssuerAddress string
+	// TreeIndex is the index of the issuer's tree that anchors this leaf.
+	TreeIndex uint64
+	// Leaf is the VC hash to verify, as a 32-byte hex string (with or without "0x").
+	Leaf string
+	// Proof is the ordered list of sibling hashes (each a 32-byte hex string) that,
+	// folded with the leaf, reconstruct the tree root. It is empty for a
+	// single-leaf tree (in which case the root equals the leaf).
+	Proof []string
+	// TxHash is the hash (32-byte hex, with or without "0x") of the transaction
+	// that anchored the tree root this proof was generated against. The proof and
+	// the tx hash must come from the same anchoring.
+	TxHash string
+}
+
+// Validate checks that the request is well-formed before hitting the chain.
+func (r *VerifyByTxRequest) Validate() error {
+	if r == nil {
+		return errors.New("verify request is required")
+	}
+
+	if !common.IsHexAddress(r.IssuerAddress) {
+		return fmt.Errorf("invalid issuer address: %q", r.IssuerAddress)
+	}
+
+	if err := validateHash32(r.Leaf); err != nil {
+		return fmt.Errorf("invalid leaf: %w", err)
+	}
+
+	for i, p := range r.Proof {
+		if err := validateHash32(p); err != nil {
+			return fmt.Errorf("invalid proof element at index %d: %w", i, err)
+		}
+	}
+
+	if err := validateHash32(r.TxHash); err != nil {
+		return fmt.Errorf("invalid tx hash: %w", err)
 	}
 
 	return nil

--- a/credential/vccontract/registry.go
+++ b/credential/vccontract/registry.go
@@ -1,6 +1,7 @@
 package vccontract
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"encoding/hex"
@@ -10,19 +11,39 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 //go:embed smartcontract/credential_registry_smc_abi.json
 var credentialRegistryABIJSON []byte
 
+// anchoredRootEvent is the log emitted by the Credential Registry when one
+// transaction anchors new roots for a batch of trees at once. Its three parallel
+// arrays are read to recover the root a specific transaction recorded.
+const anchoredRootEvent = "BatchTreesUpdated"
+
 var (
 	parsedABI    abi.ABI
 	parseABIOnce sync.Once
 	errParseABI  error
+)
+
+var (
+	// ErrTxNotFound is returned when the chain has no receipt for the tx hash,
+	// either because it is unknown or because it has not been mined yet.
+	ErrTxNotFound = errors.New("transaction not found")
+	// ErrTxReverted is returned when the tx exists but failed, so it anchored
+	// nothing.
+	ErrTxReverted = errors.New("transaction reverted")
+	// ErrRootNotAnchored is returned when the tx succeeded but carries no root
+	// for the requested issuer and tree index.
+	ErrRootNotAnchored = errors.New("transaction did not anchor a root for this issuer and tree index")
 )
 
 // loadABI parses the embedded Credential Registry ABI exactly once.
@@ -37,11 +58,14 @@ func loadABI() (abi.ABI, error) {
 // CredentialRegistry is a read-only client for the Credential Registry smart
 // contract.
 //
-// It performs on-chain reads only (eth_call) and therefore needs neither a
-// private key nor gas. Construct one with NewCredentialRegistry and release it with Close.
+// It performs on-chain reads only (eth_call and receipt reads) and therefore
+// needs neither a private key nor gas. Construct one with NewCredentialRegistry
+// and release it with Close.
 type CredentialRegistry struct {
 	client   *ethclient.Client
 	contract *bind.BoundContract
+	abi      abi.ABI
+	address  common.Address
 }
 
 // NewCredentialRegistry connects to the chain and returns a client for the
@@ -69,10 +93,14 @@ func NewCredentialRegistry(rpcURL, contractAddress string) (*CredentialRegistry,
 		return nil, fmt.Errorf("failed to load contract ABI: %w", err)
 	}
 
+	address := common.HexToAddress(contractAddress)
+
 	return &CredentialRegistry{
-		client: client,
+		client:  client,
+		address: address,
+		abi:     contractABI,
 		contract: bind.NewBoundContract(
-			common.HexToAddress(contractAddress),
+			address,
 			contractABI,
 			client,
 			client,
@@ -99,7 +127,7 @@ func (v *CredentialRegistry) VerifyVCHashOnChain(ctx context.Context, req *Verif
 		return false, err
 	}
 
-	leaf, proof, err := decodeLeafAndProof(req)
+	leaf, proof, err := decodeLeafAndProof(req.Leaf, req.Proof)
 	if err != nil {
 		return false, err
 	}
@@ -128,6 +156,113 @@ func (v *CredentialRegistry) VerifyVCHashOnChain(ctx context.Context, req *Verif
 	}
 
 	return ok, nil
+}
+
+// VerifyVCHashByTx checks the client-supplied Merkle proof components against the
+// root that a specific transaction anchored on-chain, read from that
+// transaction's receipt logs.
+//
+// This is the counterpart to VerifyVCHashOnChain for proofs that the tree's
+// current state can no longer confirm: an unsealed tree's root is overwritten by
+// each later anchoring, so a proof taken at an earlier anchoring only ever matches
+// the root recorded in that anchoring's transaction. The proof and the tx hash
+// must therefore come from the same anchoring.
+//
+// Returns true when the leaf, folded with its proof, reproduces the root that
+// req.TxHash anchored for the issuer and tree index. Returns false with a nil
+// error when the proof does not validate, when the transaction reverted, or when
+// the transaction anchored no root for this issuer and tree index. A non-nil error
+// means the check could not be completed — malformed input, RPC failure, or the
+// transaction not found / not yet mined (ErrTxNotFound).
+func (v *CredentialRegistry) VerifyVCHashByTx(ctx context.Context, req *VerifyByTxRequest) (bool, error) {
+	if err := req.Validate(); err != nil {
+		return false, err
+	}
+
+	leaf, proof, err := decodeLeafAndProof(req.Leaf, req.Proof)
+	if err != nil {
+		return false, err
+	}
+
+	txHash, err := hexToBytes32(req.TxHash)
+	if err != nil {
+		return false, fmt.Errorf("invalid tx hash: %w", err)
+	}
+
+	root, err := v.GetAnchoredRoot(
+		ctx,
+		common.Hash(txHash),
+		common.HexToAddress(req.IssuerAddress),
+		req.TreeIndex,
+	)
+	switch {
+	// The transaction reverted or records no root for this tree, so it cannot
+	// attest the leaf: a definitive "not verified", not a failure to check.
+	case errors.Is(err, ErrTxReverted), errors.Is(err, ErrRootNotAnchored):
+		return false, nil
+	case err != nil:
+		return false, err
+	}
+
+	return verifyMerkleProof(leaf, proof, root), nil
+}
+
+// GetAnchoredRoot returns the Merkle root that txHash anchored on-chain for the
+// given issuer and tree index, read from the BatchTreesUpdated logs of the
+// transaction's receipt.
+//
+// A single transaction anchors many trees at once, so the event carries parallel
+// arrays and only the entry matching both the issuer and the tree index belongs
+// to the caller's tree. Returns ErrTxNotFound when no receipt exists (unknown or
+// unmined), ErrTxReverted when the transaction failed, and ErrRootNotAnchored when
+// it succeeded but recorded no root for this issuer and tree index.
+func (v *CredentialRegistry) GetAnchoredRoot(ctx context.Context, txHash common.Hash, issuer common.Address, treeIndex uint64) ([32]byte, error) {
+	var root [32]byte
+
+	receipt, err := v.client.TransactionReceipt(ctx, txHash)
+	if err != nil {
+		if errors.Is(err, ethereum.NotFound) {
+			return root, ErrTxNotFound
+		}
+
+		return root, fmt.Errorf("failed to get transaction receipt: %w", err)
+	}
+
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return root, ErrTxReverted
+	}
+
+	eventID := v.abi.Events[anchoredRootEvent].ID
+	treeIndexBig := new(big.Int).SetUint64(treeIndex)
+
+	for _, log := range receipt.Logs {
+		// Unpacking a log does not check which contract emitted it, so a
+		// lookalike event from any other address must be rejected here.
+		if log.Address != v.address {
+			continue
+		}
+
+		if len(log.Topics) == 0 || log.Topics[0] != eventID {
+			continue
+		}
+
+		event, err := unpackAnchoredRoot(v.abi, log)
+		if err != nil {
+			continue
+		}
+
+		for i := range event.Issuers {
+			if i >= len(event.TreeIndices) || i >= len(event.NewRoots) {
+				break
+			}
+
+			if event.Issuers[i] == issuer && event.TreeIndices[i].Cmp(treeIndexBig) == 0 {
+				return event.NewRoots[i], nil
+			}
+		}
+	}
+
+	return root, ErrRootNotAnchored
 }
 
 // GetTreeRoot returns the on-chain Merkle root for the given issuer and tree
@@ -191,15 +326,68 @@ func (v *CredentialRegistry) HasTree(ctx context.Context, issuerAddress string, 
 	return exists, nil
 }
 
-// decodeLeafAndProof converts the hex request fields into the byte forms the
-// contract call expects.
-func decodeLeafAndProof(req *VerifyRequest) ([32]byte, [][32]byte, error) {
-	leaf, err := hexToBytes32(req.Leaf)
+// batchTreesUpdated mirrors the non-indexed fields of the BatchTreesUpdated
+// event, in declaration order.
+type batchTreesUpdated struct {
+	Issuers     []common.Address
+	TreeIndices []*big.Int
+	NewRoots    [][32]byte
+}
+
+// unpackAnchoredRoot decodes a BatchTreesUpdated log's data into its parallel
+// arrays. All three event fields are non-indexed, so they live entirely in the
+// log's data section.
+func unpackAnchoredRoot(contractABI abi.ABI, log *types.Log) (batchTreesUpdated, error) {
+	var event batchTreesUpdated
+
+	err := contractABI.UnpackIntoInterface(&event, anchoredRootEvent, log.Data)
+	if err != nil {
+		return batchTreesUpdated{}, err
+	}
+
+	return event, nil
+}
+
+// verifyMerkleProof reports whether leaf, folded together with its sibling path,
+// reproduces root.
+//
+// The tree hashes each sibling pair in sorted order with keccak256 and does not
+// re-hash the leaves, so the fold is independent of the leaf's position and needs
+// no leaf index. This mirrors the contract's own verifyVC folding, letting a proof
+// be checked against a historical root recovered from a transaction's receipt. An
+// empty proof means a single-leaf tree, where the root equals the leaf.
+func verifyMerkleProof(leaf [32]byte, proof [][32]byte, root [32]byte) bool {
+	computed := leaf
+	for _, sibling := range proof {
+		computed = hashPair(computed, sibling)
+	}
+
+	return computed == root
+}
+
+// hashPair keccak256-hashes two 32-byte nodes concatenated in ascending byte
+// order, matching the contract's sorted-pair hashing.
+func hashPair(a, b [32]byte) [32]byte {
+	var out [32]byte
+
+	if bytes.Compare(a[:], b[:]) < 0 {
+		copy(out[:], crypto.Keccak256(a[:], b[:]))
+	} else {
+		copy(out[:], crypto.Keccak256(b[:], a[:]))
+	}
+
+	return out
+}
+
+// decodeLeafAndProof converts the hex leaf and proof fields into the byte forms
+// the contract call and local folding expect.
+func decodeLeafAndProof(leafHex string, proofHex []string) ([32]byte, [][32]byte, error) {
+	leaf, err := hexToBytes32(leafHex)
 	if err != nil {
 		return [32]byte{}, nil, fmt.Errorf("invalid leaf: %w", err)
 	}
 
-	proof, err := parseProof(req.Proof)
+	proof, err := parseProof(proofHex)
 	if err != nil {
 		return [32]byte{}, nil, err
 	}

--- a/credential/vccontract/registry_test.go
+++ b/credential/vccontract/registry_test.go
@@ -14,6 +14,10 @@ func mkLeaf(b byte) [32]byte {
 	return l
 }
 
+func hexOf(b [32]byte) string {
+	return "0x" + hex.EncodeToString(b[:])
+}
+
 func TestHexToBytes32(t *testing.T) {
 	want := mkLeaf(0xcd)
 	hexStr := "0x" + hex.EncodeToString(want[:])
@@ -73,5 +77,122 @@ func TestVerifyRequestValidate(t *testing.T) {
 	badLeaf.Leaf = "0xabcd"
 	if err := badLeaf.Validate(); err == nil {
 		t.Fatal("expected error for malformed leaf")
+	}
+}
+
+func TestVerifyByTxRequestValidate(t *testing.T) {
+	valid := &VerifyByTxRequest{
+		IssuerAddress: "0x1111111111111111111111111111111111111111",
+		TreeIndex:     0,
+		Leaf:          hexOf(mkLeaf(0x01)),
+		Proof:         []string{hexOf(mkLeaf(0x02))},
+		TxHash:        hexOf(mkLeaf(0x03)),
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid request rejected: %v", err)
+	}
+
+	badIssuer := *valid
+	badIssuer.IssuerAddress = "not-an-address"
+	if err := badIssuer.Validate(); err == nil {
+		t.Fatal("expected error for invalid issuer address")
+	}
+
+	badTx := *valid
+	badTx.TxHash = "0xabcd"
+	if err := badTx.Validate(); err == nil {
+		t.Fatal("expected error for malformed tx hash")
+	}
+
+	missingTx := *valid
+	missingTx.TxHash = ""
+	if err := missingTx.Validate(); err == nil {
+		t.Fatal("expected error for empty tx hash")
+	}
+}
+
+// TestVerifyMerkleProof builds a small tree with the same sorted-pair keccak256
+// hashing the contract uses and checks each leaf's proof folds up to the root.
+func TestVerifyMerkleProof(t *testing.T) {
+	a, b, c, d := mkLeaf(0x0a), mkLeaf(0x0b), mkLeaf(0x0c), mkLeaf(0x0d)
+
+	// A four-leaf tree: root = H(H(a,b), H(c,d)).
+	ab := hashPair(a, b)
+	cd := hashPair(c, d)
+	root := hashPair(ab, cd)
+
+	cases := []struct {
+		name  string
+		leaf  [32]byte
+		proof [][32]byte
+	}{
+		{"leaf a", a, [][32]byte{b, cd}},
+		{"leaf b", b, [][32]byte{a, cd}},
+		{"leaf c", c, [][32]byte{d, ab}},
+		{"leaf d", d, [][32]byte{c, ab}},
+	}
+
+	for _, tc := range cases {
+		if !verifyMerkleProof(tc.leaf, tc.proof, root) {
+			t.Fatalf("%s: valid proof rejected", tc.name)
+		}
+
+		// A wrong sibling must not verify.
+		bad := append([][32]byte{}, tc.proof...)
+		bad[0] = mkLeaf(0xff)
+		if verifyMerkleProof(tc.leaf, bad, root) {
+			t.Fatalf("%s: tampered proof accepted", tc.name)
+		}
+	}
+
+	// Wrong leaf against a valid path must fail.
+	if verifyMerkleProof(mkLeaf(0xee), [][32]byte{b, cd}, root) {
+		t.Fatal("unexpected: wrong leaf accepted")
+	}
+}
+
+// TestVerifyMerkleProofSingleLeaf covers a single-leaf tree, where the root
+// equals the leaf and the proof is empty.
+func TestVerifyMerkleProofSingleLeaf(t *testing.T) {
+	leaf := mkLeaf(0x42)
+
+	if !verifyMerkleProof(leaf, nil, leaf) {
+		t.Fatal("single-leaf proof rejected")
+	}
+
+	if verifyMerkleProof(leaf, nil, mkLeaf(0x43)) {
+		t.Fatal("single-leaf proof accepted against wrong root")
+	}
+}
+
+// TestHashPairSorted confirms sibling order does not change the parent hash.
+func TestHashPairSorted(t *testing.T) {
+	a, b := mkLeaf(0x01), mkLeaf(0x02)
+	if hashPair(a, b) != hashPair(b, a) {
+		t.Fatal("hashPair is not order-independent")
+	}
+}
+
+// TestHashPairKnownVector pins the fold to an independently computed keccak256
+// vector, guarding against an accidental swap to SHA3-256 (which shares Go's
+// sha3 package but uses different padding). The expected values were produced by
+// a separate keccak256 implementation over the same sorted-pair rule.
+func TestHashPairKnownVector(t *testing.T) {
+	a, b, c, d := mkLeaf(0x0a), mkLeaf(0x0b), mkLeaf(0x0c), mkLeaf(0x0d)
+
+	const wantAB = "0d0f9871649057367c9802ed72c3863f53b2d28ae3d10ece2d4ef0d2f9213784"
+	if got := hashPair(a, b); hex.EncodeToString(got[:]) != wantAB {
+		t.Fatalf("hashPair keccak mismatch: got %x want %s", got, wantAB)
+	}
+
+	const wantRoot = "94d1872730575cc36cfe8dc134c661933532c76cacf4512666feeb402206ca29"
+	root := hashPair(hashPair(a, b), hashPair(c, d))
+	if hex.EncodeToString(root[:]) != wantRoot {
+		t.Fatalf("root keccak mismatch: got %x want %s", root, wantRoot)
+	}
+
+	// The public proof path must reach the same verdict as the raw fold.
+	if !verifyMerkleProof(a, [][32]byte{b, hashPair(c, d)}, root) {
+		t.Fatal("verifyMerkleProof rejected a proof that folds to the known root")
 	}
 }

--- a/credential/vccontract/smartcontract/credential_registry_smc_abi.json
+++ b/credential/vccontract/smartcontract/credential_registry_smc_abi.json
@@ -30,5 +30,15 @@
     "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address[]", "name": "issuers", "type": "address[]" },
+      { "indexed": false, "internalType": "uint256[]", "name": "treeIndices", "type": "uint256[]" },
+      { "indexed": false, "internalType": "bytes32[]", "name": "newRoots", "type": "bytes32[]" }
+    ],
+    "name": "BatchTreesUpdated",
+    "type": "event"
   }
 ]


### PR DESCRIPTION
###  Description

#### Overview
This PR introduces a new verification path `VerifyVCHashByTx` to the `vccontract` package. Unlike `VerifyVCHashOnChain` which validates a Merkle proof against the tree's *current* root, this new method allows clients to verify a Verifiable Credential (VC) hash locally against the specific root anchored by a historical transaction. 

This is particularly useful for **unsealed trees** where the current on-chain root keeps moving forward, making older proofs invalid against the latest root.

#### Key Changes
* **Core Implementation**: Added `VerifyVCHashByTx` and `GetAnchoredRoot` methods to `CredentialRegistry`.
* **Data Models**: Introduced `VerifyByTxRequest` struct along with its respective validation rules (`Validate()`).
* **Documentation**: Updated `README.md` and `model.go` to explain the two distinct verification paths (*Against current root* vs. *Against specific transaction*).
* **Examples**: Added a complete runnable example under `credential/vccontract/example/verifybytx/main.go` demonstrating how to use the new method.

#### How to Test
You can run the new example using the following command:
```bash
go run ./credential/vccontract/example/verifybytx