### PR TITLE
feat: add field TermsOfUse

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,40 @@ a bare object — `termsOfUse` always serializes as an array. An entry with an e
 is rejected with an error. The property is omitted entirely when the slice is empty.
 
 The spec does not define any concrete terms-of-use types; `IssuerPolicy` and `HolderPolicy`
-are illustrative. If your policy type needs a resolvable JSON-LD identity, define it in a
-custom `@context` entry (see the [Example](#vc-example) below) — otherwise it resolves
-against whatever `@vocab` your contexts happen to supply.
+are illustrative.
+
+#### Declaring your policy type
+
+Your policy type **must** be declared in `@context` — either through an `@vocab` mapping or
+by using an absolute IRI as the type. The base context
+`https://www.w3.org/ns/credentials/v2` defines the `termsOfUse` *property*, but it defines
+no policy types and carries **no `@vocab`**, so an undeclared type has nothing to resolve
+against:
+
+```
+// @context: ["https://www.w3.org/ns/credentials/v2"]
+_:c14n0 <...#type> <PresentationRequiredPolicy> .           // relative IRI — not a valid absolute IRI
+
+// @context: [..., {"@vocab": "https://ndadid.vn/ns#"}]
+_:c14n0 <...#type> <https://ndadid.vn/ns#PresentationRequiredPolicy> .
+```
+
+This is **mandatory** for the `ecdsa-rdfc-2019` and `ecdsa-sd-2023` proof suites, which sign
+over canonicalized RDF: a relative IRI is resolved differently by different JSON-LD
+processors, producing a different canonical form and therefore a different hash, so a
+third-party verifier can reject a credential this SDK considers valid. JWT credentials do
+not canonicalize and are unaffected — but a credential issued today may be re-issued under
+a Data Integrity proof later.
+
+#### Selective disclosure and `mandatoryPointers`
+
+Under `ecdsa-sd-2023`, pass `/termsOfUse` in the mandatory paths given to
+`AddProofByProvider`. The SDK adds nothing to that list on your behalf. If the policy is
+left selectively disclosable, a holder can derive a proof that omits `termsOfUse` entirely,
+and the verifier sees a well-formed, correctly signed credential carrying no policy — with
+no indication that anything was removed. This differs from `credentialStatus`: dropping
+status leaves the verifier aware it cannot check revocation, whereas dropping `termsOfUse`
+leaves it unaware there was ever a condition.
 
 ### Parsing a Verifiable Credential
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,43 @@ To create a Verifiable Credential, you need:
 4. Add a cryptographic proof using `AddProof()` with a signer provider
 5. Serialize and verify the credential
 
+### Terms of Use
+
+`CredentialContents.TermsOfUse` maps to the W3C `termsOfUse` property, which lets an
+issuer state the conditions under which a credential may be used. `Type` is required,
+`ID` is optional:
+
+```go
+vcc := vc.CredentialContents{
+	// ... other contents ...
+	TermsOfUse: []vc.TermsOfUse{
+		{Type: "PresentationRequiredPolicy"},
+		{ID: "https://example.com/policies/credential/4", Type: "IssuerPolicy"},
+	},
+}
+```
+
+Produces:
+
+```json
+"termsOfUse": [
+  { "type": "PresentationRequiredPolicy" },
+  {
+    "id": "https://example.com/policies/credential/4",
+    "type": "IssuerPolicy"
+  }
+]
+```
+
+Unlike `credentialStatus` and `credentialSchema`, a single entry is **not** collapsed into
+a bare object — `termsOfUse` always serializes as an array. An entry with an empty `Type`
+is rejected with an error. The property is omitted entirely when the slice is empty.
+
+The spec does not define any concrete terms-of-use types; `IssuerPolicy` and `HolderPolicy`
+are illustrative. If your policy type needs a resolvable JSON-LD identity, define it in a
+custom `@context` entry (see the [Example](#vc-example) below) — otherwise it resolves
+against whatever `@vocab` your contexts happen to supply.
+
 ### Parsing a Verifiable Credential
 
 1. Use `vc.ParseCredential()` to parse both JSON and JWT credentials

--- a/credential/vc/credential.go
+++ b/credential/vc/credential.go
@@ -58,6 +58,7 @@ type CredentialContents struct {
 	CredentialStatus []Status      `json:"credentialStatus,omitempty"` // Credential status entries
 	Subject          []Subject     `json:"subject,omitempty"`          // Credential subjects
 	Schemas          []Schema      `json:"schemas,omitempty"`          // Credential schemas
+	TermsOfUse       []TermsOfUse  `json:"termsOfUse,omitempty"`       // Terms of use policies
 }
 
 // Status represents the credentialStatus field as per W3C Verifiable Credentials.
@@ -79,6 +80,12 @@ type Subject struct {
 type Schema struct {
 	ID   string `json:"id,omitempty"`   // Schema identifier
 	Type string `json:"type,omitempty"` // Schema type
+}
+
+// TermsOfUse represents a termsOfUse entry as per W3C Verifiable Credentials.
+type TermsOfUse struct {
+	ID   string `json:"id,omitempty"` // Policy identifier
+	Type string `json:"type"`         // Policy type
 }
 
 // Decoy specifies where and how many decoy digests to add for SD-JWT privacy.

--- a/credential/vc/credential_helper.go
+++ b/credential/vc/credential_helper.go
@@ -136,6 +136,15 @@ func normalizeValue(v interface{}) interface{} {
 		return normalizeMap(map[string]interface{}(val))
 	case map[string]interface{}:
 		return normalizeMap(val)
+	case []CredentialData:
+		// util.MapSlice returns []CredentialData, which generic processors do not
+		// recognise: json-gold stringifies it into a literal instead of walking it
+		// as a list of nodes. Widen it to []interface{} so the entries survive.
+		out := make([]interface{}, len(val))
+		for i, e := range val {
+			out[i] = normalizeMap(map[string]interface{}(e))
+		}
+		return out
 	case []interface{}:
 		out := make([]interface{}, len(val))
 		for i, e := range val {

--- a/credential/vc/credential_helper.go
+++ b/credential/vc/credential_helper.go
@@ -85,6 +85,11 @@ func serializeCredentialContents(vcc *CredentialContents) (CredentialData, error
 	}
 
 	if len(vcc.CredentialStatus) > 0 {
+		for i, term := range vcc.CredentialStatus {
+			if term.Type == "" {
+				return nil, fmt.Errorf("credentialStatus[%d].type is required", i)
+			}
+		}
 		vcJSON["credentialStatus"] = serializeStatuses(vcc.CredentialStatus)
 	}
 
@@ -201,14 +206,10 @@ func serializeStatuses(statuses []Status) interface{} {
 
 // serializeStatus converts a single Status struct to a JSON object.
 func serializeStatus(status Status) CredentialData {
-	result := make(CredentialData)
+	result := CredentialData{"type": status.Type}
 
 	if status.ID != "" {
 		result["id"] = status.ID
-	}
-
-	if status.Type != "" {
-		result["type"] = status.Type
 	}
 
 	if status.StatusPurpose != "" {

--- a/credential/vc/credential_helper.go
+++ b/credential/vc/credential_helper.go
@@ -85,8 +85,8 @@ func serializeCredentialContents(vcc *CredentialContents) (CredentialData, error
 	}
 
 	if len(vcc.CredentialStatus) > 0 {
-		for i, term := range vcc.CredentialStatus {
-			if term.Type == "" {
+		for i, status := range vcc.CredentialStatus {
+			if status.Type == "" {
 				return nil, fmt.Errorf("credentialStatus[%d].type is required", i)
 			}
 		}

--- a/credential/vc/credential_helper.go
+++ b/credential/vc/credential_helper.go
@@ -88,6 +88,15 @@ func serializeCredentialContents(vcc *CredentialContents) (CredentialData, error
 		vcJSON["credentialStatus"] = serializeStatuses(vcc.CredentialStatus)
 	}
 
+	if len(vcc.TermsOfUse) > 0 {
+		for i, term := range vcc.TermsOfUse {
+			if term.Type == "" {
+				return nil, fmt.Errorf("termsOfUse[%d].type is required", i)
+			}
+		}
+		vcJSON["termsOfUse"] = util.MapSlice(vcc.TermsOfUse, serializeTermsOfUse)
+	}
+
 	if !vcc.ValidFrom.IsZero() {
 		vcJSON["validFrom"] = vcc.ValidFrom.Format(time.RFC3339)
 	}
@@ -212,6 +221,18 @@ func serializeStatus(status Status) CredentialData {
 
 	if status.StatusListCredential != "" {
 		result["statusListCredential"] = status.StatusListCredential
+	}
+
+	return result
+}
+
+// serializeTermsOfUse converts a single TermsOfUse struct to a JSON object.
+// Type is required by the W3C data model, so it is always written.
+func serializeTermsOfUse(term TermsOfUse) CredentialData {
+	result := CredentialData{"type": term.Type}
+
+	if term.ID != "" {
+		result["id"] = term.ID
 	}
 
 	return result

--- a/credential/vc/credential_test.go
+++ b/credential/vc/credential_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/pilacorp/go-credential-sdk/credential/common/dto"
 	"github.com/pilacorp/go-credential-sdk/credential/common/jwt"
+	"github.com/pilacorp/go-credential-sdk/credential/common/processor"
 	"github.com/pilacorp/go-credential-sdk/credential/common/sdjwt"
 	"github.com/pilacorp/go-credential-sdk/credential/common/signer"
 )
@@ -2112,5 +2114,100 @@ func TestSerializeCredentialContents_TermsOfUse(t *testing.T) {
 		assert.NoError(t, json.Unmarshal(contents, &payload))
 		assert.Len(t, payload.TermsOfUse, 1)
 		assert.Equal(t, "PresentationRequiredPolicy", payload.TermsOfUse[0].Type)
+	})
+}
+
+func TestSerializeCredentialContents_CredentialStatusTypeRequired(t *testing.T) {
+	baseContents := func() CredentialContents {
+		return CredentialContents{
+			Context: []interface{}{"https://www.w3.org/ns/credentials/v2"},
+			ID:      "urn:uuid:1234",
+			Issuer:  "did:example:issuer",
+			Types:   []string{"VerifiableCredential"},
+			Subject: []Subject{{ID: "did:example:holder"}},
+		}
+	}
+
+	t.Run("missing type is rejected", func(t *testing.T) {
+		vcc := baseContents()
+		vcc.CredentialStatus = []Status{
+			{ID: "https://example.com/status/0#0", Type: "BitstringStatusListEntry"},
+			{ID: "https://example.com/status/0#1", StatusPurpose: "revocation"},
+		}
+
+		_, err := serializeCredentialContents(&vcc)
+		assert.EqualError(t, err, "credentialStatus[1].type is required")
+	})
+
+	t.Run("type is always written", func(t *testing.T) {
+		vcc := baseContents()
+		vcc.CredentialStatus = []Status{{
+			ID:            "https://example.com/status/0#0",
+			Type:          "BitstringStatusListEntry",
+			StatusPurpose: "revocation",
+		}}
+
+		out, err := serializeCredentialContents(&vcc)
+		assert.NoError(t, err)
+
+		status, ok := out["credentialStatus"].(CredentialData)
+		assert.True(t, ok, "a single status collapses to an object, got %T", out["credentialStatus"])
+		assert.Equal(t, "BitstringStatusListEntry", status["type"])
+	})
+}
+
+// relativeIRIPattern matches an N-Quads IRI with no scheme — `<Foo>` rather than
+// `<https://example.com/Foo>`. Such IRIs are not valid absolute IRIs, and JSON-LD
+// processors are free to resolve them differently, which changes the canonical
+// form and therefore any signature computed over it.
+var relativeIRIPattern = regexp.MustCompile(`<[A-Za-z][A-Za-z0-9_-]*>`)
+
+func TestTermsOfUse_CanonicalizationProducesAbsoluteIRIs(t *testing.T) {
+	contentsWithContext := func(ctx []interface{}) map[string]interface{} {
+		vcc := CredentialContents{
+			Context: ctx,
+			ID:      "urn:uuid:1234",
+			Issuer:  "did:example:issuer",
+			Types:   []string{"VerifiableCredential"},
+			Subject: []Subject{{ID: "did:example:holder"}},
+			TermsOfUse: []TermsOfUse{
+				{Type: "PresentationRequiredPolicy"},
+			},
+		}
+
+		out, err := serializeCredentialContents(&vcc)
+		assert.NoError(t, err)
+
+		return normalizeCredentialData(out)
+	}
+
+	t.Run("a declared policy type canonicalizes to an absolute IRI", func(t *testing.T) {
+		doc := contentsWithContext([]interface{}{
+			"https://www.w3.org/ns/credentials/v2",
+			map[string]interface{}{"@vocab": "https://example.com/vocab#"},
+		})
+
+		nq, err := processor.CanonicalizeDocument(doc)
+		assert.NoError(t, err)
+
+		assert.Contains(t, string(nq), "<https://example.com/vocab#PresentationRequiredPolicy>")
+		assert.NotRegexp(t, relativeIRIPattern, string(nq),
+			"canonicalized n-quads must not contain relative IRIs")
+	})
+
+	t.Run("control: an undeclared policy type degrades to a relative IRI", func(t *testing.T) {
+		// This is the trap the README warns about. Asserting it explicitly keeps
+		// the invariant above meaningful: if a future context change silently
+		// started declaring the term, this test would catch that the two cases
+		// are no longer distinct.
+		doc := contentsWithContext([]interface{}{
+			"https://www.w3.org/ns/credentials/v2",
+		})
+
+		nq, err := processor.CanonicalizeDocument(doc)
+		assert.NoError(t, err)
+
+		assert.Contains(t, string(nq), "<PresentationRequiredPolicy>")
+		assert.Regexp(t, relativeIRIPattern, string(nq))
 	})
 }

--- a/credential/vc/credential_test.go
+++ b/credential/vc/credential_test.go
@@ -2014,3 +2014,103 @@ func newSignedJWTCredential(t *testing.T) Credential {
 	}
 	return cred
 }
+
+func TestSerializeCredentialContents_TermsOfUse(t *testing.T) {
+	baseContents := func() CredentialContents {
+		return CredentialContents{
+			Context: []interface{}{"https://www.w3.org/ns/credentials/v2"},
+			ID:      "urn:uuid:1234",
+			Issuer:  "did:example:issuer",
+			Types:   []string{"VerifiableCredential"},
+			Subject: []Subject{{ID: "did:example:holder"}},
+		}
+	}
+
+	t.Run("omitted when empty", func(t *testing.T) {
+		vcc := baseContents()
+
+		out, err := serializeCredentialContents(&vcc)
+		assert.NoError(t, err)
+
+		_, present := out["termsOfUse"]
+		assert.False(t, present, "termsOfUse must be absent when no entries are set")
+	})
+
+	t.Run("single entry stays an array", func(t *testing.T) {
+		vcc := baseContents()
+		vcc.TermsOfUse = []TermsOfUse{{Type: "PresentationRequiredPolicy"}}
+
+		out, err := serializeCredentialContents(&vcc)
+		assert.NoError(t, err)
+
+		terms, ok := out["termsOfUse"].([]CredentialData)
+		assert.True(t, ok, "termsOfUse must serialize to an array, got %T", out["termsOfUse"])
+		assert.Len(t, terms, 1)
+		assert.Equal(t, CredentialData{"type": "PresentationRequiredPolicy"}, terms[0])
+	})
+
+	t.Run("optional id is carried through", func(t *testing.T) {
+		vcc := baseContents()
+		vcc.TermsOfUse = []TermsOfUse{{
+			ID:   "https://example.com/policies/credential/4",
+			Type: "IssuerPolicy",
+		}}
+
+		out, err := serializeCredentialContents(&vcc)
+		assert.NoError(t, err)
+
+		terms := out["termsOfUse"].([]CredentialData)
+		assert.Len(t, terms, 1)
+		assert.Equal(t, CredentialData{
+			"id":   "https://example.com/policies/credential/4",
+			"type": "IssuerPolicy",
+		}, terms[0])
+	})
+
+	t.Run("multiple entries keep their order", func(t *testing.T) {
+		vcc := baseContents()
+		vcc.TermsOfUse = []TermsOfUse{
+			{Type: "PresentationRequiredPolicy"},
+			{Type: "IssuerPolicy", ID: "https://example.com/policies/credential/4"},
+		}
+
+		out, err := serializeCredentialContents(&vcc)
+		assert.NoError(t, err)
+
+		terms := out["termsOfUse"].([]CredentialData)
+		assert.Len(t, terms, 2)
+		assert.Equal(t, "PresentationRequiredPolicy", terms[0]["type"])
+		assert.Equal(t, "IssuerPolicy", terms[1]["type"])
+	})
+
+	t.Run("missing type is rejected", func(t *testing.T) {
+		vcc := baseContents()
+		vcc.TermsOfUse = []TermsOfUse{
+			{Type: "PresentationRequiredPolicy"},
+			{ID: "https://example.com/policies/credential/4"},
+		}
+
+		_, err := serializeCredentialContents(&vcc)
+		assert.EqualError(t, err, "termsOfUse[1].type is required")
+	})
+
+	t.Run("survives a JWT build and parse round trip", func(t *testing.T) {
+		vcc := baseContents()
+		vcc.TermsOfUse = []TermsOfUse{{Type: "PresentationRequiredPolicy"}}
+
+		cred, err := NewJWTCredential(vcc, WithVerificationMethodKey("key-1"))
+		assert.NoError(t, err)
+
+		contents, err := cred.GetContents()
+		assert.NoError(t, err)
+
+		var payload struct {
+			TermsOfUse []struct {
+				Type string `json:"type"`
+			} `json:"termsOfUse"`
+		}
+		assert.NoError(t, json.Unmarshal(contents, &payload))
+		assert.Len(t, payload.TermsOfUse, 1)
+		assert.Equal(t, "PresentationRequiredPolicy", payload.TermsOfUse[0].Type)
+	})
+}


### PR DESCRIPTION
## Add `termsOfUse` to `CredentialContents`

Lets an issuer state the conditions under which a credential may be used, per
W3C VCDM 2.0 §5.5. `Type` is required, `ID` is optional. Unlike
`credentialStatus` and `credentialSchema`, a single entry is **not** collapsed
into a bare object — `termsOfUse` always serializes as an array, so consumers
only ever handle one shape.

```go
TermsOfUse: []vc.TermsOfUse{
    {Type: "PresentationRequiredPolicy"},
    {ID: "https://example.com/policies/credential/4", Type: "IssuerPolicy"},
}
```

## ⚠️ Behaviour change beyond the title: `credentialStatus` (commit d3a11ab)

This PR also makes `type` required on `credentialStatus`, not just on
`termsOfUse`.

**Before:** a `Status` with an empty `Type` was silently skipped, producing a
non-conformant credential that was still signed and issued successfully.
**After:** `serializeCredentialContents` returns
`credentialStatus[i].type is required` and the credential build **fails**.

Anyone constructing a `vc.Status` without a `Type` will now hit an error at
credential build time. I audited every construction site in the monorepo:
`createBitstringStatusListEntry` and both migration scripts always set `Type`,
so nothing breaks today. The one path that did not guarantee it is
`go-auth-sdk/auth/status`, which builds a `vc.Status` straight from the status
provider's HTTP response — handled separately in that repo, where the error
message can still point at the response that caused it.

W3C requires `type` on both properties, and `termsOfUse` was already validated,
so this is the consistent direction. It is still a behaviour change on an
already-released field, which is why it is called out here.

## Drive-by fix: `normalizeValue` did not handle `[]CredentialData`

Pre-existing bug on `main`, surfaced by the new RDF canonicalization tests.
`util.MapSlice` returns `[]CredentialData`, a type missing from the
`normalizeValue` switch, so it fell through to `default`. json-gold then
stringified the whole slice into a single literal instead of walking it as a
list of nodes:

```
<urn:uuid:1234> <...#termsOfUse> "[map[type:PresentationRequiredPolicy]]" .
```

This affected any multi-entry `credentialStatus`, `credentialSchema` or
`credentialSubject` signed with a Data Integrity proof. JWT credentials were
unaffected — they go through `json.Marshal`, which handles the type fine.
`termsOfUse` hit it unconditionally because it never collapses to an object.

Fixed at the root by adding a `[]CredentialData` case, which covers all four
properties at once.

## Tests

- `TestSerializeCredentialContents_TermsOfUse` — omitted when empty, single
  entry stays an array, optional `id`, ordering, missing `type` rejected,
  survives a JWT build/parse round trip
- `TestSerializeCredentialContents_CredentialStatusTypeRequired` — covers the
  new validation branch above
- `TestTermsOfUse_CanonicalizationProducesAbsoluteIRIs` — runs through URDNA2015
  and asserts a declared policy type yields an absolute IRI with no relative
  IRIs left in the n-quads, plus a control case asserting that an *undeclared*
  type does degrade to a relative IRI, so the invariant cannot quietly lose its
  meaning. Both W3C contexts are embedded, so these run offline.

## Docs

README gains two sections: policy types **must** be declared in `@context`
(the base `credentials/v2` context defines the `termsOfUse` property but carries
no `@vocab` and no policy types — mandatory for `ecdsa-rdfc-2019` and
`ecdsa-sd-2023`, irrelevant for JWT), and a warning to pass `/termsOfUse` in
`mandatoryPointers` under `ecdsa-sd-2023` — otherwise a holder can derive a
proof omitting the policy entirely, and the verifier sees a well-formed,
correctly signed credential with no indication anything was removed.